### PR TITLE
Commit automatically with static text 'Released version $NUMBER' and publish to NPM repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "gulp-git": "^0.4.3",
     "gulp-prompt": "^0.1.1",
     "gulp-tag-version": "^1.0.2",
+    "through2": "2.0.0",
     "yargs": "^1.3.1"
   },
   "devDependencies": {

--- a/tasks/release.js
+++ b/tasks/release.js
@@ -1,72 +1,82 @@
-module.exports = function(gulp){
-  var argv, bump, filter, fs, git, paths, prompt, tag_version, versioning;
+module.exports = function (gulp) {
+    var argv, bump, filter, fs, git, paths, prompt, tag_version, versioning, spawn, through;
 
-  fs = require('fs');
-  prompt = require('gulp-prompt');
-  git = require('gulp-git');
-  bump = require('gulp-bump');
-  filter = require('gulp-filter');
-  tag_version = require('gulp-tag-version');
-  argv = require('yargs').argv;
+    argv = require('yargs').argv;
+    bump = require('gulp-bump');
+    filter = require('gulp-filter');
+    fs = require('fs');
+    git = require('gulp-git');
+    prompt = require('gulp-prompt');
+    spawn = require('child_process').spawn;
+    tag_version = require('gulp-tag-version');
+    through = require('through2');
 
-  var versioningFiles = function(){
-    if(argv.bower){
-      return ['./bower.json']
-    }
-    if(argv.npm || argv.node){
-      return ['./package.json']
-    }
-    if(fs.existsSync('package.json') && fs.existsSync('bower.json')){
-      return ['./package.json', './bower.json']
-    } else {
-      return ['./package.json']
-    }
-  };
+    var versioningFiles = function () {
+        if (argv.bower) {
+            return ['./bower.json']
+        }
+        if (argv.npm || argv.node) {
+            return ['./package.json']
+        }
+        if (fs.existsSync('package.json') && fs.existsSync('bower.json')) {
+            return ['./package.json', './bower.json']
+        } else {
+            return ['./package.json']
+        }
+    };
 
-  var bumpPreference = fs.existsSync('package.json')  ? 'package.json' : 'bower.json';
-  var vFiles         = versioningFiles();
+    var bumpPreference = fs.existsSync('package.json') ? 'package.json' : 'bower.json';
+    var vFiles = versioningFiles();
 
-  paths = {
-    versionsToBump: vFiles,
-    version: bumpPreference,
-    dest: '.'
-  };
+    paths = {
+        versionsToBump: vFiles,
+        version: bumpPreference,
+        dest: '.'
+    };
 
-  gulp.task('tag', ['bump', 'commit'], function() {
-    return gulp.src(paths.versionsToBump).pipe(filter(paths.version)).pipe(tag_version()).pipe(git.push('origin', 'master', {
-      args: '--tags'
-    }));
-  });
+    gulp.task('tag', ['bump', 'commit', 'npm-publish'], function () {
+        return gulp.src(paths.versionsToBump).pipe(filter(paths.version)).pipe(tag_version()).pipe(git.push('origin', 'master', {
+            args: '--tags'
+        }));
+    });
 
-  gulp.task('add', function() {
-    return gulp.src(paths.versionsToBump).pipe(git.add());
-  });
+    gulp.task('npm-publish', function (done) {
+        spawn('npm', ['publish'], {stdio: 'inherit'}).on('close', done);
+    });
 
-  gulp.task('commit', ['add'], function() {
-    return gulp.src(paths.version).pipe(prompt.prompt({
-      type: 'input',
-      name: 'commit',
-      message: 'enter a commit msg, eg initial commit'
-    }, function(res) {
-      return gulp.src('.').pipe(git.commit(res.commit));
-    }));
-  });
+    gulp.task('add', function () {
+        return gulp.src(paths.versionsToBump).pipe(git.add());
+    });
 
-  versioning = function() {
-    if (argv.minor || argv.feature) {
-      return 'minor';
-    }
-    if (argv.major) {
-      return 'major';
-    }
-    return 'patch';
-  };
+    var commitIt = function(file, enc, cb) {
+        if (file.isNull()) return cb(null, file);
+        if (file.isStream()) return cb(new Error('Streaming not supported'));
 
-  gulp.task('bump', function() {
-    return gulp.src(paths.versionsToBump).pipe(bump({
-      type: versioning()
-    })).pipe(gulp.dest(paths.dest));
-  });
+        var commitMessage = "Released version " + require(file.path).version;
+        gulp.src('.').pipe(git.commit(commitMessage));
+
+        cb(null, file);
+    };
+
+    gulp.task('commit', ['add'], function () {
+        return gulp.src(paths.version).pipe(through.obj(commitIt));
+    });
+
+    versioning = function () {
+        if (argv.minor || argv.feature) {
+            return 'minor';
+        }
+        if (argv.major) {
+            return 'major';
+        }
+        return 'patch';
+    };
+
+    gulp.task('bump', function () {
+        return gulp.src(paths.versionsToBump).pipe(bump({
+            type: versioning()
+        })).pipe(gulp.dest(paths.dest));
+    });
 
 
 };


### PR DESCRIPTION
PR which makes behavior of the plugin like this one: https://github.com/geddski/grunt-release

It is quite annoying always add commit message, as it is releasing and can be static + publishing to NPM, which is nice to have as a part of the release flow.
